### PR TITLE
Updated gulp-jshint to version 1.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "chai": "1.10.0",
     "gulp": "3.8.11",
-    "gulp-jshint": "1.9.2",
+    "gulp-jshint": "1.11.2",
     "gulp-mocha": "2.0.0",
     "jshint-stylish": "1.0.0",
     "mocha": "2.1.0"


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
