### PR TITLE
Fixed error if not returned plugin name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var postcss = require('postcss');
 
-module.exports = function (opts) {
+module.exports = postcss.plugin('postcss-banner', function (opts) {
     opts = opts || {};
 
     function process(value) {
@@ -32,7 +32,4 @@ module.exports = function (opts) {
             css.append(footer);
         }
     };
-};
-module.exports.postcss = function (css) {
-    return module.exports()(css);
-};
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-banner",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "PostCSS plugin to add text banner to resulting file",
   "keywords": [
     "postcss",
@@ -23,6 +23,7 @@
     "gulp": "3.9.0",
     "gulp-jshint": "2.0.0",
     "gulp-mocha": "2.2.0",
+    "jshint": "^2.9.1",
     "jshint-stylish": "2.0.1",
     "mocha": "2.4.1"
   },


### PR DESCRIPTION
I use the plugin postcss-devtool if it is not to pass the name of the plugin it does not work and corrected the mistakes jshint
